### PR TITLE
Added Ruby library ortegacmanuel/kroniko

### DIFF
--- a/docs/resources/libraries.md
+++ b/docs/resources/libraries.md
@@ -16,6 +16,10 @@ But there are already a couple of libraries and libraries that prove those in pr
 - `wwwision/dcb-eventstore`[:octicons-link-external-16:](https://github.com/bwaidelich/dcb-eventstore){:target="_blank" .small} (work in progress)
 - `gember/event-sourcing`[:octicons-link-external-16:](https://github.com/GemberPHP/event-sourcing){:target="_blank" .small} (work in progress)
 
+#### Ruby
+
+- `ortegacmanuel/kroniko`[:octicons-link-external-16:](https://github.com/ortegacmanuel/kroniko){:target="_blank" .small} (work in progress)
+
 ## Add your own
 
 If you are working on a library related to DCB or on a compatible (see [specification](../specification.md)) Event Store, feel free to open a Pull request in the Github Repository[:octicons-link-external-16:](https://github.com/dcb-events/dcb-events.github.io){:target="_blank" .small} of this website to add it to the list above


### PR DESCRIPTION
## Description

Added Ruby library ortegacmanuel/kroniko, a file-based DCB compatible Event Store in Ruby. There are more details on how this is DCB compatible [here](https://github.com/ortegacmanuel/kroniko?tab=readme-ov-file#-dcb-compatibility)