### PR TITLE
Replace `Sequence Position` with `Event Id`

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -62,7 +62,7 @@ However, we’re experimenting with an adapter layer that allows traditional Eve
 
 ## Nothing comes for free. What are limitations/drawbacks of DCB?
 
-DCB guarantees consistency only inside the scope of the global [Sequence Position](specification.md#sequence-position). Thus, Events must be ordered to allow the conditional appending.
+DCB guarantees consistency only inside the scope of the global Sequence Position (TODO: Adjust!). Thus, Events must be ordered to allow the conditional appending.
 As a result, it’s not (easily) possible to partition Events.
 Furthermore, DCB leads to some additional complexity in the Event Store implementation (see [Specification](specification.md)).
 


### PR DESCRIPTION
## Todos

- [x] Remove notion of `Sequenced Event` and `Sequence Position` from specification and examples
- [x] Introduce concept of a `Event Id` that is part of the [Event](https://dcb.events/specification/#event) (globally unique for one event store, might be created by client or server (we don't care))
- [ ] Discuss: Mention `Stored Event` or not
- [ ] Think about ways to version the specification (maybe a change log at the bottom of the page?)
- [ ] Adjust [FAQ](https://dcb.events/faq/#how-can-it-be-used-with-a-traditional-event-store) (not exposing the sequence position might allow for parallel writes, i.e. partitioning)

Resolves: #27