### PR TITLE
Web sites displays "C" instead of "C#"

### DIFF
--- a/docs/resources/libraries.md
+++ b/docs/resources/libraries.md
@@ -3,9 +3,9 @@
 DCB is merely a set of ideas and concepts.
 But there are already a couple of libraries and libraries that prove those in practice:
 
-#### C#
+#### C\#
 
-- `Sekiban.Dcb`[:octicons-link-external-16:](https://github.com/J-Tech-Japan/Sekiban?tab=readme-ov-file#dcb-dynamic-consistency-boundary){:target="_blank" .small} (active dev, PostgreSQL support, NuGet preview: [`1.0.1-preview24`](https://www.nuget.org/packages/Sekiban.Dcb), using Orleans Actor Model)
+- `Sekiban.Dcb`[:octicons-link-external-16:](https://github.com/J-Tech-Japan/Sekiban?tab=readme-ov-file#dcb-dynamic-consistency-boundary){:target="_blank" .small} (active dev, PostgreSQL support, [`Sekiban.Dcb Nuget Package`](https://www.nuget.org/packages/Sekiban.Dcb), using Orleans Actor Model)
 
 #### Go
 

--- a/docs/resources/libraries.md
+++ b/docs/resources/libraries.md
@@ -37,10 +37,6 @@ But there are already a couple of libraries and libraries that prove those in pr
 - Disintegrate `disintegrate-es/disintegrate`[:octicons-link-external-16:](https://disintegrate-es.github.io/disintegrate/){:target="_blank" .small} (slightly different approach, inspired by the original ideas of DCB)
 - `dcbdb`[:octicons-link-external-16:](https://github.com/johnbywater/dcbdb){:target="_blank" .small} (work in progress)
 
-#### C#
-
-- `Sekiban.Dcb`[:octicons-link-external-16:](https://github.com/J-Tech-Japan/Sekiban?tab=readme-ov-file#dcb-dynamic-consistency-boundary){:target="_blank" .small} (active dev, PostgreSQL support, NuGet preview: [`1.0.1-preview24`](https://www.nuget.org/packages/Sekiban.Dcb), using Orleans Actor Model)
-
 ## Add your own
 
 If you are working on a library related to DCB or on a compatible (see [specification](../specification.md)) Event Store, feel free to open a Pull request in the Github Repository[:octicons-link-external-16:](https://github.com/dcb-events/dcb-events.github.io/edit/main/docs/resources/libraries.md){:target="_blank" .small} of this website to add it to the list above

--- a/docs/resources/libraries.md
+++ b/docs/resources/libraries.md
@@ -37,6 +37,10 @@ But there are already a couple of libraries and libraries that prove those in pr
 - Disintegrate `disintegrate-es/disintegrate`[:octicons-link-external-16:](https://disintegrate-es.github.io/disintegrate/){:target="_blank" .small} (slightly different approach, inspired by the original ideas of DCB)
 - `dcbdb`[:octicons-link-external-16:](https://github.com/johnbywater/dcbdb){:target="_blank" .small} (work in progress)
 
+#### C#
+
+- `Sekiban.Dcb`[:octicons-link-external-16:](https://github.com/J-Tech-Japan/Sekiban?tab=readme-ov-file#dcb-dynamic-consistency-boundary){:target="_blank" .small} (active dev, PostgreSQL support, NuGet preview: [`1.0.1-preview24`](https://www.nuget.org/packages/Sekiban.Dcb/1.0.1-preview24), using Orleans Actor Model)
+
 ## Add your own
 
 If you are working on a library related to DCB or on a compatible (see [specification](../specification.md)) Event Store, feel free to open a Pull request in the Github Repository[:octicons-link-external-16:](https://github.com/dcb-events/dcb-events.github.io/edit/main/docs/resources/libraries.md){:target="_blank" .small} of this website to add it to the list above

--- a/docs/resources/libraries.md
+++ b/docs/resources/libraries.md
@@ -39,7 +39,7 @@ But there are already a couple of libraries and libraries that prove those in pr
 
 #### C#
 
-- `Sekiban.Dcb`[:octicons-link-external-16:](https://github.com/J-Tech-Japan/Sekiban?tab=readme-ov-file#dcb-dynamic-consistency-boundary){:target="_blank" .small} (active dev, PostgreSQL support, NuGet preview: [`1.0.1-preview24`](https://www.nuget.org/packages/Sekiban.Dcb/1.0.1-preview24), using Orleans Actor Model)
+- `Sekiban.Dcb`[:octicons-link-external-16:](https://github.com/J-Tech-Japan/Sekiban?tab=readme-ov-file#dcb-dynamic-consistency-boundary){:target="_blank" .small} (active dev, PostgreSQL support, NuGet preview: [`1.0.1-preview24`](https://www.nuget.org/packages/Sekiban.Dcb), using Orleans Actor Model)
 
 ## Add your own
 


### PR DESCRIPTION
<img width="851" height="583" alt="Screenshot 2025-08-24 at 08 42 55" src="https://github.com/user-attachments/assets/b9c297be-9b07-455f-aae0-265b48b0e5b8" />

I am not sure how to fix for GitHub Pages, but this is what copilot suggest to display "C#"