### PR TITLE
Add backslashphp/backslash to PHP libraries

### DIFF
--- a/docs/resources/libraries.md
+++ b/docs/resources/libraries.md
@@ -23,6 +23,7 @@ But there are already a couple of libraries and libraries that prove those in pr
 
 - `wwwision/dcb-eventstore`[:octicons-link-external-16:](https://github.com/bwaidelich/dcb-eventstore){:target="_blank" .small} (work in progress)
 - `gember/event-sourcing`[:octicons-link-external-16:](https://github.com/GemberPHP/event-sourcing){:target="_blank" .small} (work in progress)
+- `backslashphp/backslash`[:octicons-link-external-16:](https://github.com/backslashphp/backslash){:target="_blank" .small} (fully documented, demo application available)
 
 #### Python
 


### PR DESCRIPTION
Added a link to my PHP library in docs/resources/libraries.md

Backslash is a personal project I started in 2017 to explore Event Sourcing and CQRS. It has been used in production across several internal corporate systems. I recently refactored the codebase to adopt DCB (previously built around aggregates), and it’s a total game changer. Thank you for your excellent work!