### PR TITLE
Rename "Boundary" to "Boundaries"

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,6 +1,6 @@
 # About this website 
 
-This website was created with the aim of spreading awareness about the concept of the **Dynamic Consistency Boundary** (DCB).
+This website was created with the aim of spreading awareness about the concept of **Dynamic Consistency Boundaries** (DCB).
 
 Our goals are threefold:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 
 ## What is it?
 
-Dynamic Consistency Boundary (DCB) is a technique for enforcing consistency in event-driven systems without relying on rigid transactional boundaries.
+Dynamic Consistency Boundaries (DCB) is a technique for enforcing consistency in event-driven systems without relying on rigid transactional boundaries.
 
 Traditional systems use strict constraints to maintain immediate consistency, while event-driven architectures embrace eventual consistency for scalability and resilience. However, this flexibility raises challenges in defining where and how consistency should be enforced.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Dynamic Consistency Boundary
+site_name: Dynamic Consistency Boundaries
 site_description: DCB – A simpler and more flexible approach to consistency in event-driven systems
 site_url: https://dcb.events
 theme:
@@ -37,7 +37,7 @@ theme:
 
 nav:
   - DCB:
-    - Dynamic Consistency Boundary: index.md
+    - Home: index.md
     - Specification: specification.md
   - Examples:
       - examples/index.md


### PR DESCRIPTION
The "B" of DCB was not called Boundaries (plural form) consistently