### PR TITLE
Add Occurrent to the Java and Kotlin library lists

### DIFF
--- a/docs/resources/libraries.md
+++ b/docs/resources/libraries.md
@@ -38,6 +38,7 @@ Open Source Event Store specifically written to support DCB via gRPC API by John
 #### Java
 
 - Axon Framework [:octicons-link-external-16:](https://www.axoniq.io/framework){:target="_blank" .small} Event Sourcing Framework with support for DCB since version 5
+- Occurrent [:octicons-link-external-16:](https://occurrent.org/documentation#dynamic-consistency-boundary){:target="_blank" .small} Event Sourcing library for the JVM based on CloudEvents, composed from small framework-agnostic modules with optional Spring Boot starters, where DCB and stream-based event sourcing share the same Event Store and the domain model does not have to depend on Occurrent
 - `@sliceworkz/eventstore`[:octicons-link-external-16:](https://github.com/sliceworkz/eventstore){:target="_blank" .small} DCB-Compliant Eventstore in Java/Postgres (Open Source - LGPL)
 
 
@@ -49,6 +50,7 @@ Open Source Event Store specifically written to support DCB via gRPC API by John
 #### Kotlin
 
 - `FactStore` [:octicons-link-external-16:](https://github.com/fact-store/factstore){:target="_blank" .small} (work in progress)
+- Occurrent [:octicons-link-external-16:](https://occurrent.org/documentation#dcb-query-dsl){:target="_blank" .small} Kotlin DSLs for DCB deciders and criteria on the library listed under Java, with the [dcb.events example patterns](https://github.com/johanhaleby/occurrent/tree/main/example/domain/dcb-patterns) implemented in Kotlin
 
 #### PHP
 


### PR DESCRIPTION
[Occurrent](https://occurrent.org/) is an event sourcing library for the JVM built on CloudEvents. It got DCB support in 0.30.0, so I think it belongs on this list.

Two things here might interest your readers. DCB and the classic one-stream-per-aggregate style run on the same event store, so an application can use both without picking one up front. Occurrent is also a set of small libraries rather than a framework, so the domain model doesn't have to depend on it.

I've listed it under both Java and Kotlin, because the Kotlin DSL is an API of its own rather than a thin wrapper over the Java one. Let me know if you'd rather keep one entry per project and I'll collapse it to Java.

The Kotlin entry links an example module that implements the patterns from your examples page (unique username, idempotency, dynamic product price, opt-in token and invoice number).
