### PR TITLE
add tephra to libraries.md

### DIFF
--- a/docs/resources/libraries.md
+++ b/docs/resources/libraries.md
@@ -17,7 +17,7 @@ Commercial product with DCB support via HTTP API by [the native web](https://www
 
 ### Tephra [:octicons-link-external-16:](https://tephra.tqwewe.com/){:target="_blank" .small}
 
-Open Source Event Store written in Rust, supporting DCB via a binary TCP protocol using Protobuf, by [Ari Seyhun](https://github.com/tqwewe){:target="_blank"}
+Open Source Event Store written in Rust with DCB support via a custom Protobuf-over-TCP protocol by [Ari Seyhun](https://github.com/tqwewe){:target="_blank"}
 
 ### UmaDB [:octicons-link-external-16:](https://umadb.io/){:target="_blank" .small}
 

--- a/docs/resources/libraries.md
+++ b/docs/resources/libraries.md
@@ -15,6 +15,10 @@ Commercial product with DCB support via gRPC/HTTP API by [AxonIQ](https://www.ax
 
 Commercial product with DCB support via HTTP API by [the native web](https://www.thenativeweb.io/){:target="_blank"}
 
+### Tephra [:octicons-link-external-16:](https://tephra.tqwewe.com/){:target="_blank" .small}
+
+Open Source Event Store written in Rust, supporting DCB via a binary TCP protocol using Protobuf, by [Ari Seyhun](https://github.com/tqwewe){:target="_blank"}
+
 ### UmaDB [:octicons-link-external-16:](https://umadb.io/){:target="_blank" .small}
 
 Open Source Event Store specifically written to support DCB via gRPC API by John Bywater


### PR DESCRIPTION
As I've been sharing in the DCB Discord, I've built Tephra, an open source event store purpose built for DCB.

It's written in Rust, implements the full DCB specification, and has a test suite covering the spec's append conditions and query semantics. Docs and getting started guide at https://tephra.tqwewe.com/.

Adding it to the DCB Compliant Event Stores section alongside existing event stores.