### PR TITLE
Add DCB Campfire event series to about page and announcement banner

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -62,6 +62,18 @@ Come chat with us and other people interested in DCB on our Discord server – w
 
 ---
 
+## DCB Campfire
+
+*DCB Campfire* is an open, biweekly meeting for developers interested in Dynamic Consistency Boundaries.
+
+Bring your questions, ideas, experiments, or solutions – whether you're just getting started with DCB or already using it in production. Share what you're working on, discuss challenges, explore new approaches, or simply join the conversation.
+
+No agenda, no slides required – just developers curious about DCB.
+
+[:material-calendar-month: Join the DCB Campfire](https://luma.com/dcb.events){:target="_blank" .md-button .md-button--primary}
+
+---
+
 ## Contact Us
 
 For collaborations, suggestions, or just to connect, feel free to reach out to us via email [:material-email:](mailto:hello%40dcb.events){.small} or through our social profiles.

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -187,6 +187,28 @@ codapi-output a[href="#close"] {
     }
 }
 
+.dcb-announce-bar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 1em;
+}
+
+.dcb-announce__divider {
+    display: inline-block;
+    width: 1px;
+    height: 1em;
+    background: currentcolor;
+    opacity: .4;
+}
+
+@media (max-width: 480px) {
+    .dcb-announce__divider {
+        display: none;
+    }
+}
+
 .dcb-announce {
     display: flex;
     align-items: center;

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,10 +1,19 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  <a href="https://discord.gg/hmfHwuxMft" target="_blank" rel="noopener" class="dcb-announce">
-    <span class="dcb-announce__icon">
-      {% include ".icons/simple/discord.svg" %}
-    </span>
-    Questions, ideas or feedback? Join the DCB Discord server
-  </a>
+  <div class="dcb-announce-bar">
+    <a href="https://discord.gg/hmfHwuxMft" target="_blank" rel="noopener" class="dcb-announce">
+      <span class="dcb-announce__icon">
+        {% include ".icons/simple/discord.svg" %}
+      </span>
+      Join the DCB Discord server
+    </a>
+    <span class="dcb-announce__divider"></span>
+    <a href="https://luma.com/dcb.events" target="_blank" rel="noopener" class="dcb-announce">
+      <span class="dcb-announce__icon">
+        {% include ".icons/material/calendar-month.svg" %}
+      </span>
+      Join the DCB Campfire meetup
+    </a>
+  </div>
 {% endblock %}


### PR DESCRIPTION
Links to the new biweekly community meetup on Luma from the about page and the site-wide announcement bar, alongside the Discord link.